### PR TITLE
🎈 perf: 时钟树拖拽缩放性能优化

### DIFF
--- a/common/settings.py
+++ b/common/settings.py
@@ -89,13 +89,8 @@ class Settings(QConfig):
                                  "Auto",
                                  OptionsValidator([1, 1.25, 1.5, 1.75, 2, "Auto"]),
                                  restart=True)
-    isUseOpenGL = ConfigItem("System", "UseOpenGL", True, BoolValidator(), restart=True)
+    isUseOpenGL = ConfigItem("System", "UseOpenGL", False, BoolValidator(), restart=True)
     openGLSamples = OptionsConfigItem("System", "OpenGLSamples", 4, OptionsValidator([4, 8, 12, 16]), restart=True)
-    clockTreeType = OptionsConfigItem("System",
-                                      "ClockTreeType",
-                                      "Pixmap",
-                                      OptionsValidator(["Pixmap", "Svg"]),
-                                      restart=True)
 
     # update
     isUpdateAtStartup = ConfigItem("Update", "CheckUpdateAtStartup", True, BoolValidator())

--- a/resource/style/templates/clock_tree_view.qss.j2
+++ b/resource/style/templates/clock_tree_view.qss.j2
@@ -62,9 +62,9 @@ QLineEdit#floatWidget,#integerWidget {
 {% if valid %}
     border: 0px solid transparent;
 {% else %}
-    border: {{ 1 * multiple }}px solid red;
+    border: 1px solid red;
 {% endif %}
-    font: {{ 12 * multiple }}px "Segoe UI", "Microsoft YaHei";
+    font: 12px "Segoe UI", "Microsoft YaHei";
     padding: 0px 10px;
     selection-background-color: --ThemeColorLight1;
 }
@@ -77,7 +77,7 @@ QComboBox#enumWidget {
     color: black;
     background-color: transparent;
 {% endif %}
-    font: {{ 12 * multiple }}px "Segoe UI", "Microsoft YaHei";
+    font: 12px "Segoe UI", "Microsoft YaHei";
     selection-background-color: transparent
 }
 
@@ -89,7 +89,7 @@ QListWidget#listWidget {
     color: black;
     background-color: rgb(253, 253, 253);
 {% endif %}
-    font: {{ 12 * multiple }}px "Segoe UI", "Microsoft YaHei";
+    font: 12px "Segoe UI", "Microsoft YaHei";
 }
 
 QRadioButton#radioWidget {
@@ -102,9 +102,9 @@ QRadioButton#radioWidget {
 }
 
 QRadioButton::indicator#radioWidget {
-    width: {{ width * multiple }}px;
-    height: {{ height * multiple }}px;
-    border-radius: {{ (width * multiple)//2 }}px;
+    width: {{ width }}px;
+    height: {{ height }}px;
+    border-radius: {{ width // 2 }}px;
     background-color: transparent;
 }
 

--- a/view/clock_tree_view.py
+++ b/view/clock_tree_view.py
@@ -30,11 +30,10 @@ from pathlib import Path
 
 import jinja2
 from PySide6.QtCore import QSize
-from PySide6.QtGui import QColor, QPixmap, Qt, QPainter
+from PySide6.QtGui import QColor
 from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtSvgWidgets import QGraphicsSvgItem
-from PySide6.QtWidgets import (QWidget, QGraphicsScene, QGraphicsPixmapItem, QGraphicsProxyWidget, QGraphicsItem,
-                               QButtonGroup)
+from PySide6.QtWidgets import (QWidget, QGraphicsScene, QGraphicsPixmapItem, QGraphicsProxyWidget, QButtonGroup)
 from qfluentwidgets import isDarkTheme, BodyLabel
 
 from common import Icon, SETTINGS, PROJECT, Style, SUMMARY, IP, CLOCK_TREE
@@ -48,8 +47,6 @@ class ClockTreeView(Ui_ClockTreeView, QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setupUi(self)
-
-        self.__multiple = 1
 
         self.__resPath = Path(
             SETTINGS.DATABASE_FOLDER) / 'clock' / PROJECT.project().vendor.lower() / SUMMARY.projectSummary().clockTree.lower()
@@ -79,24 +76,9 @@ class ClockTreeView(Ui_ClockTreeView, QWidget):
 
         renderer = QSvgRenderer(self.__drawio.svg, self)
 
-        if SETTINGS.clockTreeType.value == "Pixmap":
-            self.__multiple = 5
-            pixmap = QPixmap(renderer.defaultSize() * self.__multiple)
-            pixmap.fill(Qt.GlobalColor.transparent)
-            painter = QPainter()
-            painter.begin(pixmap)
-            painter.setRenderHints(QPainter.RenderHint.Antialiasing |
-                                   QPainter.RenderHint.TextAntialiasing |
-                                   QPainter.RenderHint.SmoothPixmapTransform)
-            renderer.render(painter)
-            painter.end()
-            item = QGraphicsPixmapItem(pixmap)
-            item.setTransformationMode(Qt.TransformationMode.SmoothTransformation)
-        else:
-            self.__multiple = 1
-            item = QGraphicsSvgItem()
-            item.setMaximumCacheSize(renderer.defaultSize() * 2)
-            item.setSharedRenderer(renderer)
+        item = QGraphicsSvgItem()
+        # item.setMaximumCacheSize(renderer.defaultSize() * 2)
+        item.setSharedRenderer(renderer)
 
         return item
 
@@ -115,7 +97,6 @@ class ClockTreeView(Ui_ClockTreeView, QWidget):
         elements = self.__clockTree.elements
 
         data = {
-            "multiple": self.__multiple,
             "isDarkMode": isDarkTheme(),
         }
 
@@ -168,13 +149,12 @@ class ClockTreeView(Ui_ClockTreeView, QWidget):
                 widget.setProperty('unused', True)
                 stylesheet = f'BodyLabel {{font: 12px "Segoe UI", "Microsoft YaHei"; color: red;}}'
                 widget.setStyleSheet(stylesheet)
-            size = QSize(int(geom.width), int(geom.height)) * self.__multiple
+            size = QSize(int(geom.width), int(geom.height))
             widget.setFixedSize(size)
             # w.setProperty('config', element)
             proxy = QGraphicsProxyWidget()
             proxy.setWidget(widget)
-            proxy.setCacheMode(QGraphicsItem.CacheMode.ItemCoordinateCache, size)
-            proxy.setPos(geom.x * self.__multiple, geom.y * self.__multiple)
+            proxy.setPos(geom.x, geom.y)
             if z >= 0:
                 proxy.setZValue(z)
             elif isinstance(widget, EnumClockTreeWidget):

--- a/view/setting_view.py
+++ b/view/setting_view.py
@@ -155,19 +155,11 @@ class SystemSettingView(ScrollArea):
             configItem=SETTINGS.openGLSamples,
             texts=['4', '8', '12', '16'],
             parent=group)
-        self.clockTreeTypeCard = OptionsSettingCard(
-            configItem=SETTINGS.clockTreeType,
-            icon=Icon.LANDSCAPE,
-            title=self.tr("Clock tree type"),
-            content=self.tr("Choose the Clock tree type"),
-            texts=["Pixmap", "Svg"],
-            parent=group)
 
         group.addSettingCard(self.languageCard)
         group.addSettingCard(self.zoomCard)
         group.addSettingCard(self.useOpenGLCard)
         group.addSettingCard(self.openGLSamplesCard)
-        group.addSettingCard(self.clockTreeTypeCard)
 
         return group
 

--- a/widget/graphics_view_pan_zoom.py
+++ b/widget/graphics_view_pan_zoom.py
@@ -85,9 +85,9 @@ class GraphicsViewPanZoom(QGraphicsView):
                             QPainter.RenderHint.TextAntialiasing |
                             QPainter.RenderHint.SmoothPixmapTransform)
         self.viewport().setCursor(Qt.CursorShape.ArrowCursor)
-        INT_MAX = 2147483647
-        INT_MIN = -2147483648
-        self.setSceneRect(INT_MIN / 2, INT_MIN / 2, INT_MAX, INT_MAX)
+        # INT_MAX = 2147483647
+        # INT_MIN = -2147483648
+        # self.setSceneRect(INT_MIN / 2, INT_MIN / 2, INT_MAX, INT_MAX)
 
     def setupMatrix(self):
         scale = math.pow(2, (self.scale - (self.MIN_SCALE + self.MAX_SCALE) / 2) / self.RESOLUTION)


### PR DESCRIPTION
优化GraphicsViewPanZoom显示方式，移除无限制拖拽

只使用svg显示方式，避免出现pixmap的缩放问题
